### PR TITLE
docs: clarify Sugar environment requirements and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,49 @@
 
 ## Overview
 
-Broken-Calculator is an engaging puzzle game inspired by the Broken Calculator challenge. Players are tasked with creating five unique equations that all equal a given target number using basic arithmetic operations. This game combines creativity with mathematical thinking to build fluency in fundamental math operations.
+Broken-Calculator is an engaging puzzle game inspired by the *Broken Calculator* challenge.  
+Players are tasked with creating **five unique equations** that all evaluate to a given **target number**, using basic arithmetic operations.
+
+The activity encourages creativity and strengthens fluency in fundamental mathematical operations such as addition, subtraction, multiplication, and division.
 
 ![Game Screenshot](./screen_shots/01.png)
 
+---
+
 ## 🎮 How to Play
 
-1. **Target Number**: You'll be given a target number to reach
-2. **Create Equations**: Build five different equations using addition (+), subtraction (-), multiplication (×), and division (÷)
-3. **Get Creative**: Each equation must be unique and equal the target number
-4. **Earn Points**: Valid equations earn you points based on complexity and creativity
+1. **Target Number**  
+   You are given a target number to reach.
+
+2. **Create Equations**  
+   Build **five different equations** using:
+   - Addition (+)
+   - Subtraction (−)
+   - Multiplication (×)
+   - Division (÷)
+
+3. **Uniqueness Matters**  
+   Each equation must be **unique** and must evaluate exactly to the target number.
+
+4. **Scoring**  
+   Valid equations earn points based on their correctness and creativity.
 
 ![Gameplay Example](./screen_shots/02.png)
 
-## How to Use
+---
 
-For a step-by-step walkthrough, see the official documentation on installing activities:
+## 📦 Installation & Usage (Sugar Environment)
 
-[How to Install Activities – Sugar Labs Wiki](https://wiki.sugarlabs.org/go/How_to_install_activities)
+This activity is designed to run **inside the Sugar environment** and depends on the Sugar Toolkit (`sugar3`).
 
-Alternatively, for development or testing purposes, you may clone or copy the activity directory into your `~/Activities` folder and then restart Sugar to have it appear in the activity ring:
+For a step-by-step walkthrough on installing Sugar activities, refer to the official documentation:
+
+🔗 [How to Install Activities – Sugar Labs Wiki](https://wiki.sugarlabs.org/go/How_to_install_activities)
+
+Alternatively, for development or testing inside Sugar, you can clone or copy the activity directory into your `~/Activities` folder and restart Sugar so that it appears in the activity ring:
 
 ```bash
 git clone <repository-url> ~/Activities/<activity-name>
 
+# OR
 cp -r /path/to/local/activity ~/Activities/
-```


### PR DESCRIPTION
While trying to run the activity using a standard Python environment,
I encountered a missing **`sugar3`** dependency.

This PR clarifies that the activity is intended to run inside the Sugar
environment and improves the README to help new contributors avoid
confusion during setup.

<img width="428" height="48" alt="Screenshot 2025-12-28 230843" src="https://github.com/user-attachments/assets/deecd8f5-8732-43be-8792-f594198a73d1" />

