### PR TITLE
Disallow unary plus in equation validation

### DIFF
--- a/logic/equation_validator.py
+++ b/logic/equation_validator.py
@@ -186,6 +186,10 @@ class EquationValidator:
         if re.search(r"[^0-9+\-*/().\s]", equation):
             result["error"] = "Invalid characters in equation"
             return result
+        # Disallow unary plus to match safe_eval behaviour
+        if re.search(r"(^|\(|\s)\+", equation) :
+            result["error"] = "Unary plus is not allowed"
+            return result
         try:
             value = safe_eval(equation)
             result["value"] = value


### PR DESCRIPTION
## What does this PR do?
This PR adds validation to disallow unary plus (`+`) in equations to ensure safer evaluation behavior.

## Why is this needed?
Previously, expressions like `+5` or `1++2` were not explicitly handled, which could lead to unexpected or unsafe evaluation results.

## What was changed?
- Added a regex-based check to detect unary plus usage
- Returns a clear error message when unary plus is encountered
- Ensures compatibility with existing safe evaluation logic

## How was this tested?
Manual testing using the EquationValidator:
- Valid equations like `1+2` return correct results
- Invalid equations like `+5`, `1++2` correctly return an error
