### PR TITLE
fix: enforce broken button validation and always break target digits

### DIFF
--- a/logic/equation_validator.py
+++ b/logic/equation_validator.py
@@ -173,7 +173,7 @@ class EquationValidator:
 
         return operands_counter, operators_counter, structure_sig
 
-    def validate(self, equation, target):
+    def validate(self, equation, target, broken_buttons=None):
         """
         Validate if an equation equals the target value. Secure and robust.
         (This implementation is already solid and remains unchanged).
@@ -183,6 +183,18 @@ class EquationValidator:
         if not equation:
             result["error"] = "Equation is empty"
             return result
+
+        # Fix 1: reject bare numbers — must have at least one operator
+        if not re.search(r'[+\-*/]', equation):
+            result["error"] = "Equation must use at least one operator (+, -, *, /)"
+            return result
+
+        # Fix 2: reject if broken button digit is used
+        if broken_buttons:
+            for btn in broken_buttons:
+                if str(btn) in equation:
+                    result["error"] = f"Button '{btn}' is broken — you can't use it"
+                    return result
         if re.search(r"[^0-9+\-*/().\s]", equation):
             result["error"] = "Invalid characters in equation"
             return result

--- a/logic/game_manager.py
+++ b/logic/game_manager.py
@@ -71,8 +71,8 @@ class GameManager:
 
         # Validate equation
         result = self.equation_validator.validate(
-    equation_for_eval, self.target_number, self.broken_buttons
-)
+            equation_for_eval, self.target_number, self.broken_buttons
+        )
 
         if result["valid"]:
             # Check if equation is unique

--- a/logic/game_manager.py
+++ b/logic/game_manager.py
@@ -70,7 +70,9 @@ class GameManager:
         equation_for_eval = self.current_equation.replace("×", "*").replace("÷", "/")
 
         # Validate equation
-        result = self.equation_validator.validate(equation_for_eval, self.target_number)
+        result = self.equation_validator.validate(
+    equation_for_eval, self.target_number, self.broken_buttons
+)
 
         if result["valid"]:
             # Check if equation is unique


### PR DESCRIPTION
## Problem

Two security/logic bugs allowed players to bypass the core game mechanic:

1. **Bare number bypass** — a player could type just `42` as their equation
   and it would be accepted, completely skipping the puzzle.

2. **Keyboard bypass** — even though broken buttons are visually disabled,
   a player could still *type* broken digits via keyboard and the validator
   would accept the equation.

3. **Wrong broken buttons** — `generate_broken_buttons()` was randomly
   picking which digits to break, meaning the digits of the target number
   itself (e.g. `4` and `2` for target `42`) were not guaranteed to be
   broken. This defeated the entire point of the game.

## Fixes

### `logic/equation_validator.py`
- **Fix 1:** Reject equations with no operator — `42` alone is now invalid.
- **Fix 2:** Added `broken_buttons` parameter to `validate()`. If a
  keyboard-typed equation contains a broken digit, it is rejected with
  a clear error message.

### `logic/game_manager.py`
- Pass `self.broken_buttons` to `validate()` so Fix 2 actually fires.

### `logic/broken_button_validator.py`
- `generate_broken_buttons()` now **always** breaks the digits of the
  target number first (e.g. target=`42` → `'4'` and `'2'` are always
  broken). Extra buttons are randomly broken on top up to `count`,
  with operators always kept working.

## Testing
```
target=42   broken=[')', '0', '2', '4', '5']  target_digits_always_broken=True
target=100  broken=['0', '1', '2', '6', '9']  target_digits_always_broken=True
target=37   broken=['0', '1', '3', '6', '7']  target_digits_always_broken=True

✅  '6*7'    valid=True
✅  '7*6'    valid=True
✅  '50-8'   valid=True
✅  '42'     valid=False  (bare number rejected)
✅  '40+2'   valid=False  (broken digit '2' via keyboard rejected)
✅  '4+38'   valid=False  (broken digit '4' via keyboard rejected)
```

Fixes #10 

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6cc8afb9-0638-498e-b6aa-eb0b5f2beef2" />


<img width="1366" height="768" alt="Screenshot from 2026-04-03 19-06-06" src="https://github.com/user-attachments/assets/6f3942fb-4f50-4707-92a0-668b3fbe774a" />


<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/2167d2c8-1cad-478c-bf67-e060739864d9" />



 