### PR TITLE
Bugfix/issue 8 clipboard copy

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -360,4 +360,5 @@ Scoring:
         pass
 
     def write_file(self, file_path):
-        pass
+        with open(file_path, 'w') as f:
+            f.write('')

--- a/activity.py
+++ b/activity.py
@@ -29,6 +29,8 @@ from logic.game_manager import GameManager
 from view.ui import CalculatorUI
 from gettext import gettext as _
 
+import json
+
 
 class BrokenCalculator(Activity):
     def __init__(self, handle):
@@ -357,8 +359,48 @@ Scoring:
         self._update_ui_from_gamestate()
 
     def read_file(self, file_path):
-        pass
+        """Restore a previously saved game state from the Journal."""
+        
+        try:
+            with open(file_path, 'r') as f:
+                game_state = json.load(f)
+            
+            self.game.target_number    = game_state.get('target_number', 0)
+            self.game.equations        = game_state.get('equations', [])
+            self.game.current_equation = game_state.get('current_equation', '')
+            self.game.total_score      = game_state.get('total_score', 0)
+            self.game.game_completed   = game_state.get('game_completed', False)
+            self.game.broken_buttons   = game_state.get('broken_buttons', [])
+            
+            for value, button in self.ui.buttons.items():
+                button.set_sensitive(True)
+                button.get_style_context().remove_class('broken')
+            
+            for broken_value in self.game.broken_buttons:
+                if broken_value in self.ui.buttons:
+                    button = self.ui.buttons[broken_value]
+                    button.set_sensitive(False)
+                    button.get_style_context().add_class('broken')
+            
+            self._update_ui_from_gamestate()
+            
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            print(f"Error loading game state: {e}")
+            self._on_new_game_clicked(None)
 
     def write_file(self, file_path):
+        """Save the current game state to the Journal."""
+        
+        game_state = {
+            'target_number':   self.game.target_number,
+            'equations':       self.game.equations,
+            'current_equation': self.game.current_equation,
+            'total_score':     self.game.total_score,
+            'game_completed':  self.game.game_completed,
+            'broken_buttons':  self.game.broken_buttons,
+        }
+        
         with open(file_path, 'w') as f:
-            f.write('')
+            json.dump(game_state, f)
+        
+        self.metadata['mime_type'] = 'text/plain'

--- a/logic/game_manager.py
+++ b/logic/game_manager.py
@@ -109,11 +109,3 @@ class GameManager:
     def complete_game(self):
         """Handle game completion. This now only sets the state flag."""
         self.game_completed = True
-
-    def write_file(filename):
-        """Write game state to a file."""
-        pass
-
-    def read_file(filename):
-        """Read game state from a file."""
-        pass


### PR DESCRIPTION
fix: #8 

### Root Cause
The `write_file()` and `read_file()` methods in activity.py were left as pass meaning the activity never wrote any data to the Journal when stopped. Sugar requires every activity to implement these methods to create a valid Journal entry.

### Solution 
add implementation to both  `write_file()` and `read_file()`  and verified using the video below

https://github.com/user-attachments/assets/c161fe8e-9b3f-4707-8f90-5b4773e55234

