### PR TITLE
fix: block broken button digits typed via keyboard

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -247,7 +247,14 @@ Scoring:
     def _on_entry_changed(self, entry):
         """Update internal state as user types."""
         if not self.game.game_completed:
-            self.game.current_equation = entry.get_text()
+            text = entry.get_text()
+            for broken in self.game.broken_buttons:
+                if str(broken) in text:
+                    text = text.replace(str(broken), "")
+                    entry.set_text(text)
+                    entry.set_position(-1)
+                    return
+            self.game.current_equation = text
 
     def _on_button_clicked(self, button):
         value = button.game_value


### PR DESCRIPTION

**Problem**

Even though broken buttons were visually disabled and unclickable, a player could still type broken digits directly via keyboard into the equation display, bypassing the core game mechanic.

**Fix**

In _on_entry_changed() in activity.py, added real-time keyboard input filtering — if a broken digit is typed, it is silently removed from the display immediately, keeping the game mechanic consistent whether using mouse or keyboard.

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/fea3a81e-5fdc-4125-bca4-90361a3aedcd" />
